### PR TITLE
changes for Feeds

### DIFF
--- a/src/components/pages/PatientsSummary/functions.js
+++ b/src/components/pages/PatientsSummary/functions.js
@@ -7,19 +7,37 @@ import { themeConfigs } from '../../../themes.config';
  *
  * @return {number}
  */
-export function getInitialPanelsNumber() {
-    const defaultPanelsNumber = 4;
-    const hiddenCorePlugins = get(themeConfigs, 'corePluginsToHide', []);
-    return defaultPanelsNumber - hiddenCorePlugins.length;
+function getInitialPanelsNumber() {
+  const defaultPanelsNumber = 4;
+  const hiddenCorePlugins = get(themeConfigs, 'corePluginsToHide', []);
+  return defaultPanelsNumber - hiddenCorePlugins.length;
+}
+
+
+/**
+ * This function return the number of synopsis panels for none-core plugins
+ *
+ * @return {number}
+ */
+function getNonCorePanelsNumber(testStoreContent) {
+  let result = 0;
+  const plugins = Object.keys(testStoreContent);
+  plugins.forEach(item => {
+    if (item !== 'fetchFeedsRequest') {
+      result++;
+    }
+  });
+  return result;
 }
 
 /**
+ * This function return the total number of synopsis panels
  *
  * @param testStoreContent
- * @return {*}
+ * @return {number}
  */
 export function getPanelsNumber(testStoreContent) {
-    const initialNumber = getInitialPanelsNumber();
-    const pluginsNumber = Object.keys(testStoreContent).length;
-    return (pluginsNumber > 0) ? (initialNumber + pluginsNumber) : initialNumber;
+  const initialNumber = getInitialPanelsNumber();
+  const pluginsNumber = getNonCorePanelsNumber(testStoreContent);
+  return (pluginsNumber > 0) ? (initialNumber + pluginsNumber) : initialNumber;
 }


### PR DESCRIPTION
Total number of pannels at PatientSummary page = 
Core plugin pannels (Allergies, Medications, Contacts, Diagnosis)
+
Non-core plugin pannels (by default: 0)

Non-core panels  number depends on number of requests in:
**src/components/theme/config/synopsisRequests.js**

If we install Feeds-plugin, object themeSynopsisRequests = {} will include request for Feeds.
But Feeds-panels are hidden by default and we don't calculated them in unit tests. So, when we calculate Non-core plugin pannels, we don't calculate request for Feeds.

