### PR TITLE
remove all parts of Feeds-plugin

### DIFF
--- a/src/components/pages/PatientsSummary/FeedsPanel.js
+++ b/src/components/pages/PatientsSummary/FeedsPanel.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const FeedsPanel = props => {
-    return null;
-};
-
-export default FeedsPanel;

--- a/src/components/pages/PatientsSummary/PatientsSummary.js
+++ b/src/components/pages/PatientsSummary/PatientsSummary.js
@@ -23,8 +23,7 @@ import {
   fetchPatientMedicationsSynopsisOnMount,
 } from '../../../utils/HOCs/fetch-patients.utils';
 
-import { pluginFeedsOnMount } from './non-core-utils';
-import FeedsPanel from './FeedsPanel';
+import ExtraPatientsSummaryPanels from '../../theme/components/ExtraPatientsSummaryPanels';
 
 import { themeSynopsisOnMount, themeSynopsisRequests } from '../../theme/config/synopsisRequests';
 import { dashboardVisible, dashboardBeing } from '../../../plugins.config';
@@ -48,7 +47,6 @@ const mapDispatchToProps = dispatch => ({
   lifecycle(fetchPatientContactsSynopsisOnMount),
   lifecycle(fetchPatientAllergiesSynopsisOnMount),
   lifecycle(fetchPatientMedicationsSynopsisOnMount),
-  lifecycle(pluginFeedsOnMount),
   lifecycle(themeSynopsisOnMount),
 )
 
@@ -118,7 +116,6 @@ export default class PatientsSummary extends PureComponent {
   render() {
 
     const { boards } = this.props;
-    const feeds = get(boards, 'feeds.feeds', []);
 
     const { selectedCategory, selectedViewOfBoards, isDisclaimerModalVisible, isCategory } = this.state;
     let isHasPreview = selectedViewOfBoards.full || selectedViewOfBoards.preview;
@@ -136,7 +133,7 @@ export default class PatientsSummary extends PureComponent {
               selectedCategory={selectedCategory}
               selectedViewOfBoards={selectedViewOfBoards}
               title={themeConfigs.patientsSummaryPageName}
-              feeds={feeds}
+              boards={boards}
             />
             <div className="panel-body">
               <div className="dashboard">
@@ -160,17 +157,12 @@ export default class PatientsSummary extends PureComponent {
                     : null)
                 })}
 
-                {feeds.map((item, index) => {
-                  return (
-                    <FeedsPanel
-                      key={index}
-                      item={item}
-                      handleGoToState={this.handleGoToState}
-                      isHasPreview={isHasPreview}
-                      isHasList={isHasList}
-                    />
-                  );
-                })}
+                <ExtraPatientsSummaryPanels
+                  boards={boards}
+                  handleGoToState={this.handleGoToState}
+                  isHasPreview={isHasPreview}
+                  isHasList={isHasList}
+                />
 
               </div>
             </div>

--- a/src/components/pages/PatientsSummary/__tests__/PatientsSummary.test.js
+++ b/src/components/pages/PatientsSummary/__tests__/PatientsSummary.test.js
@@ -107,7 +107,6 @@ describe('Component <PatientsSummary />', () => {
         .dive()
         .dive()
         .dive()
-        .dive()
         .dive();
 
     expect(component).toMatchSnapshot();
@@ -168,7 +167,6 @@ describe('Component <PatientsSummary />', () => {
         .dive()
         .dive()
         .dive()
-        .dive()
         .dive();
 
     expect(component).toMatchSnapshot();
@@ -188,7 +186,6 @@ describe('Component <PatientsSummary />', () => {
         onCategorySelected={testProps.onCategorySelected}
         selectedCategory={testProps.selectedCategory}
       />, { context })
-        .dive()
         .dive()
         .dive()
         .dive()

--- a/src/components/pages/PatientsSummary/__tests__/__snapshots__/PatientsSummary.test.js.snap
+++ b/src/components/pages/PatientsSummary/__tests__/__snapshots__/PatientsSummary.test.js.snap
@@ -17,7 +17,42 @@ exports[`Component <PatientsSummary /> should renders Feeds correctly 1`] = `
         className="panel panel-primary panel-dashboard"
       >
         <PatientsSummaryListHeader
-          feeds={Array []}
+          boards={
+            Object {
+              "allergies": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "contacts": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "medications": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "problems": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+            }
+          }
           onCategorySelected={[Function]}
           onViewOfBoardsSelected={[Function]}
           selectedCategory={
@@ -126,6 +161,47 @@ exports[`Component <PatientsSummary /> should renders Feeds correctly 1`] = `
               srcPrevirew={null}
               state="contacts"
               title="Contacts"
+            />
+            <ExtraPatientsSummarySelectors
+              boards={
+                Object {
+                  "allergies": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "contacts": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "medications": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "problems": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                }
+              }
+              handleGoToState={[Function]}
+              isHasList={true}
+              isHasPreview={true}
             />
           </div>
         </div>
@@ -152,7 +228,42 @@ exports[`Component <PatientsSummary /> should renders with Disclaimer Modal corr
         className="panel panel-primary panel-dashboard"
       >
         <PatientsSummaryListHeader
-          feeds={Array []}
+          boards={
+            Object {
+              "allergies": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "contacts": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "medications": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "problems": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+            }
+          }
           onCategorySelected={[Function]}
           onViewOfBoardsSelected={[Function]}
           selectedCategory={
@@ -261,6 +372,47 @@ exports[`Component <PatientsSummary /> should renders with Disclaimer Modal corr
               srcPrevirew={null}
               state="contacts"
               title="Contacts"
+            />
+            <ExtraPatientsSummarySelectors
+              boards={
+                Object {
+                  "allergies": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "contacts": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "medications": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "problems": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                }
+              }
+              handleGoToState={[Function]}
+              isHasList={true}
+              isHasPreview={true}
             />
           </div>
         </div>
@@ -301,7 +453,42 @@ exports[`Component <PatientsSummary /> should renders with all props correctly 1
         className="panel panel-primary panel-dashboard"
       >
         <PatientsSummaryListHeader
-          feeds={Array []}
+          boards={
+            Object {
+              "allergies": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "contacts": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "medications": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+              "problems": Array [
+                Object {
+                  "text": "Loading ...",
+                },
+                "",
+                "",
+                "",
+              ],
+            }
+          }
           onCategorySelected={[Function]}
           onViewOfBoardsSelected={[Function]}
           selectedCategory={
@@ -410,6 +597,47 @@ exports[`Component <PatientsSummary /> should renders with all props correctly 1
               srcPrevirew={null}
               state="contacts"
               title="Contacts"
+            />
+            <ExtraPatientsSummarySelectors
+              boards={
+                Object {
+                  "allergies": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "contacts": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "medications": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                  "problems": Array [
+                    Object {
+                      "text": "Loading ...",
+                    },
+                    "",
+                    "",
+                    "",
+                  ],
+                }
+              }
+              handleGoToState={[Function]}
+              isHasList={true}
+              isHasPreview={false}
             />
           </div>
         </div>

--- a/src/components/pages/PatientsSummary/__tests__/__snapshots__/PatientsSummaryPanel.test.js.snap
+++ b/src/components/pages/PatientsSummary/__tests__/__snapshots__/PatientsSummaryPanel.test.js.snap
@@ -85,47 +85,7 @@ exports[`Component <PatientsSummaryPanel /> should renders with all props correc
         </Col>
       </Row>
     </div>
-    <FeedsSelectors
-      feeds={
-        Array [
-          Object {
-            "landingPageUrl": "https://www.nytimes.com/section/health",
-            "name": "NYTimes.com",
-            "rssFeedUrl": "http://rss.nytimes.com/services/xml/rss/nyt/Health.xml",
-            "sourceId": "testSourceID6",
-          },
-          Object {
-            "landingPageUrl": "http://www.bbc.co.uk/news/health",
-            "name": "BBC Health",
-            "rssFeedUrl": "http://feeds.bbci.co.uk/news/health/rss.xml?edition=uk#",
-            "sourceId": "testSourceID1",
-          },
-          Object {
-            "landingPageUrl": "https://www.nhs.uk/news/",
-            "name": "NHS Choices",
-            "rssFeedUrl": "https://www.nhs.uk/NHSChoices/shared/RSSFeedGenerator/RSSFeed.aspx?site=News",
-            "sourceId": "testSourceID2",
-          },
-          Object {
-            "landingPageUrl": "https://www.gov.uk/government/organisations/public-health-england",
-            "name": "Public Health",
-            "rssFeedUrl": "https://www.gov.uk/government/organisations/public-health-england.atom",
-            "sourceId": "testSourceID3",
-          },
-          Object {
-            "landingPageUrl": "https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/",
-            "name": "Leeds Live - Whats on",
-            "rssFeedUrl": "https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/?service=rss",
-            "sourceId": "testSourceID4",
-          },
-          Object {
-            "landingPageUrl": "https://news.leeds.gov.uk",
-            "name": "Leeds CC Local News",
-            "rssFeedUrl": "https://news.leeds.gov.uk/tagfeed/en/tags/Leeds-news",
-            "sourceId": "testSourceID5",
-          },
-        ]
-      }
+    <ExtraPatientsSummarySelectors
       toggleCheckbox={[Function]}
     />
   </div>
@@ -217,47 +177,7 @@ exports[`Component <PatientsSummaryPanel /> should renders with all props correc
         </Col>
       </Row>
     </div>
-    <FeedsSelectors
-      feeds={
-        Array [
-          Object {
-            "landingPageUrl": "https://www.nytimes.com/section/health",
-            "name": "NYTimes.com",
-            "rssFeedUrl": "http://rss.nytimes.com/services/xml/rss/nyt/Health.xml",
-            "sourceId": "testSourceID6",
-          },
-          Object {
-            "landingPageUrl": "http://www.bbc.co.uk/news/health",
-            "name": "BBC Health",
-            "rssFeedUrl": "http://feeds.bbci.co.uk/news/health/rss.xml?edition=uk#",
-            "sourceId": "testSourceID1",
-          },
-          Object {
-            "landingPageUrl": "https://www.nhs.uk/news/",
-            "name": "NHS Choices",
-            "rssFeedUrl": "https://www.nhs.uk/NHSChoices/shared/RSSFeedGenerator/RSSFeed.aspx?site=News",
-            "sourceId": "testSourceID2",
-          },
-          Object {
-            "landingPageUrl": "https://www.gov.uk/government/organisations/public-health-england",
-            "name": "Public Health",
-            "rssFeedUrl": "https://www.gov.uk/government/organisations/public-health-england.atom",
-            "sourceId": "testSourceID3",
-          },
-          Object {
-            "landingPageUrl": "https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/",
-            "name": "Leeds Live - Whats on",
-            "rssFeedUrl": "https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/?service=rss",
-            "sourceId": "testSourceID4",
-          },
-          Object {
-            "landingPageUrl": "https://news.leeds.gov.uk",
-            "name": "Leeds CC Local News",
-            "rssFeedUrl": "https://news.leeds.gov.uk/tagfeed/en/tags/Leeds-news",
-            "sourceId": "testSourceID5",
-          },
-        ]
-      }
+    <ExtraPatientsSummarySelectors
       toggleCheckbox={[Function]}
     />
   </div>

--- a/src/components/pages/PatientsSummary/header/FeedsSelectors.js
+++ b/src/components/pages/PatientsSummary/header/FeedsSelectors.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const FeedsSelectors = props => {
-  return null;
-};
-
-export default FeedsSelectors;

--- a/src/components/pages/PatientsSummary/header/PatientsSummaryListHeader.js
+++ b/src/components/pages/PatientsSummary/header/PatientsSummaryListHeader.js
@@ -25,7 +25,7 @@ export default class PatientsSummaryListHeader extends PureComponent {
 
     render() {
       const { isPatientSummaryPanelVisible } = this.state;
-      const { onCategorySelected, onViewOfBoardsSelected, selectedCategory, selectedViewOfBoards, title, feeds } = this.props;
+      const { onCategorySelected, onViewOfBoardsSelected, selectedCategory, selectedViewOfBoards, title, boards } = this.props;
 
       return (
         <div className="panel-heading">
@@ -40,7 +40,7 @@ export default class PatientsSummaryListHeader extends PureComponent {
                 selectedCategory={selectedCategory}
                 selectedViewOfBoards={selectedViewOfBoards}
                 toggleVisibility={this.togglePatientSummaryPanelVisibility}
-                feeds={feeds}
+                boards={boards}
               />}
             </div>
           </div>

--- a/src/components/pages/PatientsSummary/header/PatientsSummaryPanel.js
+++ b/src/components/pages/PatientsSummary/header/PatientsSummaryPanel.js
@@ -11,10 +11,11 @@ import { unmountOnBlur } from '../../../../utils/HOCs/unmount-on-blur.utils'
 import { patientsSummaryConfig } from '../patients-summary.config';
 import { themeConfigs } from '../../../../themes.config';
 import { dashboardBeing } from '../../../../plugins.config';
-import { getNameFromUrl } from '../../../../utils/rss-helpers';
-import FeedsSelectors from './FeedsSelectors';
+
+import ExtraPatientsSummarySelectors from '../../../theme/components/ExtraPatientsSummarySelectors';
 
 @lifecycle(unmountOnBlur)
+
 export default class PatientsSummaryPanel extends PureComponent {
   static propTypes = {
     onCategorySelected: PropTypes.func.isRequired,
@@ -51,7 +52,7 @@ export default class PatientsSummaryPanel extends PureComponent {
 
   render() {
     const { selected, selectedViewOptions } = this.state;
-    const { patientsSummaryHasPreviewSettings, feeds } = this.props;
+    const { patientsSummaryHasPreviewSettings, boards } = this.props;
 
     return (
       <div className="dropdown-menu dropdown-menu-panel dropdown-menu-summary">
@@ -75,7 +76,7 @@ export default class PatientsSummaryPanel extends PureComponent {
             </Row>
           </div>
 
-          <FeedsSelectors feeds={feeds} toggleCheckbox={this.toggleCheckbox} />
+          <ExtraPatientsSummarySelectors boards={boards} toggleCheckbox={this.toggleCheckbox} />
 
           {(themeConfigs.patientsSummaryHasPreviewSettings || patientsSummaryHasPreviewSettings) ?
             <div>

--- a/src/components/pages/PatientsSummary/non-core-utils.js
+++ b/src/components/pages/PatientsSummary/non-core-utils.js
@@ -1,3 +1,0 @@
-import React from 'react';
-
-export const pluginFeedsOnMount = {};

--- a/src/components/theme/components/ExtraPatientsSummaryPanels.js
+++ b/src/components/theme/components/ExtraPatientsSummaryPanels.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * This component returns list of panels, which creates separately (like Feeds-panels)
+ *
+ * @param props
+ * @return {XML}
+ */
+const ExtraPatientsSummarySelectors = props => {
+    return null;
+};
+
+export default ExtraPatientsSummarySelectors;

--- a/src/components/theme/components/ExtraPatientsSummarySelectors.js
+++ b/src/components/theme/components/ExtraPatientsSummarySelectors.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * This component returns list of selectors, which creates separately (like Feeds-selectors)
+ *
+ * @param props
+ * @return {XML}
+ */
+const ExtraPatientsSummarySelectors = props => {
+    return null;
+};
+
+export default ExtraPatientsSummarySelectors;


### PR DESCRIPTION
Core was updated for new method to add Feeds-plugin.

Following files were removed (because early they were overwritten when we install Feeds):
- src/components/pages/PatientsSummary/FeedsPanel.js
- src/components/pages/PatientsSummary/header/FeedsSelectors.js
- src/components/pages/PatientsSummary/non-core-utils.js

Core is linked with Feeds by two components:
<ExtraPatientsSummaryPanels /> - for Feeds panels on Summary page
<ExtraPatientsSummarySelectors /> - for Feeds selectors

These components are located in src/theme/components (outside Core) and can be overwrite when we install Feeds)