### PR TITLE
resolved the issue regarding can't get property 'type' of the link which is value is undefined or NULL

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta http-equiv="x-ua-compatible" content="IE=9">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="format-detection" content="telephone=no">
 


### PR DESCRIPTION
There was issue in IE 11: in the console the error appears:
"can't get property 'type' of the link which is value is undefined or NULL"
It was resolved by correcting the <meta http-equiv="x-ua-compatible" content="ie=edge"> to
<meta http-equiv="x-ua-compatible" content="ie=IE9"> in the index.html.