### PR TITLE
HeaderToolbar snapshot

### DIFF
--- a/src/components/containers/Header/__tests__/__snapshots__/HeaderToolbar.test.js.snap
+++ b/src/components/containers/Header/__tests__/__snapshots__/HeaderToolbar.test.js.snap
@@ -19,12 +19,12 @@ exports[`Component <HeaderToolbar /> should renders correctly 1`] = `
           onClick={[Function]}
         >
           <i
-            className="btn-icon fa fa-bars"
+            className="btn-icon fa fa-times"
           />
           <span
             className="btn-text"
           >
-            Menu
+            Close
           </span>
         </button>
         <div


### PR DESCRIPTION
The latest changes in the file HeaderToolbar.js weren't checked by unit-test.

For this reason test snapshot weren't updated.

Tests felt because Travis compared results of the latest changes with old snapshot.

