### PR TITLE
added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Use base Docker image from official Node.js repos
+# 'carbon' tracks current Long Term Support version of Node
+FROM node:carbon
+
+WORKDIR /pulsetile
+
+# install dependencies
+RUN npm install
+
+# Expose port 3000 for node server
+EXPOSE 3000
+
+CMD npm start


### PR DESCRIPTION
adds a Dockerfile to root of project

For completeness and testing I have also set up a Docker Hub automatic-build image here https://hub.docker.com/r/pacharanero/pulsetile-react-core/ (although primarily we are not using the remote prebuilt image because in the Vagrant/Docker environment we are building the Pulsetile Docker container 'to order' using a local set of development files)

closes issue #246

