### PR TITLE
Fixed bug with selecting empty item from Patient Summary screen

### DIFF
--- a/src/components/pages/Allergies/Allergies.js
+++ b/src/components/pages/Allergies/Allergies.js
@@ -74,10 +74,14 @@ export default class Allergies extends PureComponent {
     offset: 0,
     isLoading: true,
     isSubmit: false,
+    listPerPageAmount: 10,
   };
 
-  componentWillReceiveProps() {
+  componentWillReceiveProps({allAllergies}) {
+    const {listPerPageAmount} = this.state;
     const sourceId = this.context.router.route.match.params.sourceId;
+    const indexOfCurrentItem = sourceId && allAllergies ? this.formToShowCollection(allAllergies).findIndex( _.matches({sourceId: sourceId})) : null;
+    const offset = Math.floor(indexOfCurrentItem / listPerPageAmount)*listPerPageAmount;
     const userId = this.context.router.route.match.params.userId;
     const hiddenButtons = get(themeConfigs, 'buttonsToHide.allergies', []);
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.ALLERGIES}/${sourceId}` && sourceId !== undefined) {
@@ -86,7 +90,8 @@ export default class Allergies extends PureComponent {
         isDetailPanelVisible: true,
         isBtnExpandVisible: true,
         isBtnCreateVisible: isButtonVisible(hiddenButtons, 'create', true),
-        isCreatePanelVisible: false
+        isCreatePanelVisible: false,
+        offset,
       })
     }
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.ALLERGIES}/create`) {
@@ -292,7 +297,7 @@ export default class Allergies extends PureComponent {
   };
 
   render() {
-    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isLoading, isSubmit } = this.state;
+    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isLoading, isSubmit, listPerPageAmount } = this.state;
     const { allAllergies, allergiePanelFormState, allergiesCreateFormState, metaPanelFormState, allergieDetail } = this.props;
 
     const isPanelDetails = (expandedPanel === ALLERGIES_DETAIL || expandedPanel === ALLERGIE_PANEL || expandedPanel === META_PANEL || expandedPanel === SYSTEM_INFO_PANEL);
@@ -351,6 +356,7 @@ export default class Allergies extends PureComponent {
                 onCreate={this.handleCreate}
                 isLoading={isLoading}
                 id={sourceId}
+                listPerPageAmount={listPerPageAmount}
               />
             </div>
           </Col> : null}

--- a/src/components/pages/Contacts/Contacts.js
+++ b/src/components/pages/Contacts/Contacts.js
@@ -68,15 +68,19 @@ export default class Contacts extends PureComponent {
     offset: 0,
     isSubmit: false,
     isLoading: true,
+    listPerPageAmount: 10,
   };
 
-  componentWillReceiveProps() {
+  componentWillReceiveProps({allContacts}) {
+    const {listPerPageAmount} = this.state;
     const sourceId = this.context.router.route.match.params.sourceId;
+    const indexOfCurrentItem = sourceId && allContacts ? this.formToShowCollection(allContacts).findIndex( _.matches({sourceId: sourceId})) : null;
+    const offset = Math.floor(indexOfCurrentItem / listPerPageAmount)*listPerPageAmount;
     const userId = this.context.router.route.match.params.userId;
 
     //TODO should be implemented common function, and the state stored in the store Redux
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.CONTACTS}/${sourceId}` && sourceId !== undefined) {
-      this.setState({ isSecondPanel: true, isDetailPanelVisible: true, isBtnExpandVisible: true, isBtnCreateVisible: true, isCreatePanelVisible: false })
+      this.setState({ isSecondPanel: true, isDetailPanelVisible: true, isBtnExpandVisible: true, isBtnCreateVisible: true, isCreatePanelVisible: false, offset })
     }
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.CONTACTS}/create`) {
       this.setState({ isSecondPanel: true, isBtnExpandVisible: true, isBtnCreateVisible: false, isCreatePanelVisible: true, openedPanel: CONTACTS_CREATE, isDetailPanelVisible: false })
@@ -226,7 +230,7 @@ export default class Contacts extends PureComponent {
   };
 
   render() {
-    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isSubmit, isLoading } = this.state;
+    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isSubmit, isLoading, listPerPageAmount } = this.state;
     const { allContacts, contactsDetailFormState, contactsCreateFormState, metaPanelFormState, contactDetail } = this.props;
 
     const isPanelDetails = (expandedPanel === CONTACTS_DETAIL || expandedPanel === CONTACT_PANEL || expandedPanel === META_PANEL);
@@ -281,6 +285,7 @@ export default class Contacts extends PureComponent {
                 onCreate={this.handleCreate}
                 id={sourceId}
                 isLoading={isLoading}
+                listPerPageAmount={listPerPageAmount}
               />
             </div>
           </Col> : null}

--- a/src/components/pages/Diagnosis/Diagnosis.js
+++ b/src/components/pages/Diagnosis/Diagnosis.js
@@ -72,10 +72,14 @@ export default class ProblemsDiagnosis extends PureComponent {
     offset: 0,
     isSubmit: false,
     isLoading: true,
+    listPerPageAmount: 10,
   };
 
-  componentWillReceiveProps() {
+  componentWillReceiveProps({allDiagnoses}) {
+    const {listPerPageAmount} = this.state;
     const sourceId = this.context.router.route.match.params.sourceId;
+    const indexOfCurrentItem = sourceId && allDiagnoses ? this.formToShowCollection(allDiagnoses).findIndex( _.matches({sourceId: sourceId})) : null;
+    const offset = Math.floor(indexOfCurrentItem / listPerPageAmount)*listPerPageAmount;
     const userId = this.context.router.route.match.params.userId;
     const hiddenButtons = get(themeConfigs, 'buttonsToHide.diagnoses', []);
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.DIAGNOSES}/${sourceId}` && sourceId !== undefined) {
@@ -84,7 +88,8 @@ export default class ProblemsDiagnosis extends PureComponent {
         isDetailPanelVisible: true,
         isBtnCreateVisible: isButtonVisible(hiddenButtons, 'create', true),
         isBtnExpandVisible: true,
-        isCreatePanelVisible: false
+        isCreatePanelVisible: false,
+        offset
       })
     }
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.DIAGNOSES}/create`) {
@@ -281,7 +286,7 @@ export default class ProblemsDiagnosis extends PureComponent {
   };
 
   render() {
-    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isSubmit, isLoading } = this.state;
+    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isSubmit, isLoading, listPerPageAmount } = this.state;
     const { allDiagnoses, diagnosisDetail, diagnosisPanelFormState, diagnosisCreateFormState } = this.props;
 
     const isPanelDetails = (expandedPanel === DIAGNOSES_DETAIL || expandedPanel === DIAGNOSES_PANEL || expandedPanel === SYSTEM_INFO_PANEL);
@@ -344,6 +349,7 @@ export default class ProblemsDiagnosis extends PureComponent {
                 onCreate={this.handleCreate}
                 id={sourceId}
                 isLoading={isLoading}
+                listPerPageAmount={listPerPageAmount}
               />
             </div>
           </Col> : null }

--- a/src/components/pages/Medications/Medications.js
+++ b/src/components/pages/Medications/Medications.js
@@ -76,10 +76,14 @@ export default class Medications extends PureComponent {
     isSubmit: false,
     isOpenHourlySchedule: true,
     isLoading: true,
+    listPerPageAmount: 10,
   };
 
-  componentWillReceiveProps() {
+  componentWillReceiveProps({allMedications}) {
+    const {listPerPageAmount} = this.state;
     const sourceId = this.context.router.route.match.params.sourceId;
+    const indexOfCurrentItem = sourceId && allMedications ? this.formToShowCollection(allMedications).findIndex( _.matches({sourceId: sourceId})) : null;
+    const offset = Math.floor(indexOfCurrentItem / listPerPageAmount)*listPerPageAmount;
     const userId = this.context.router.route.match.params.userId;
     const hiddenButtons = get(themeConfigs, 'buttonsToHide.medications', []);
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.MEDICATIONS}/${sourceId}` && sourceId !== undefined) {
@@ -88,7 +92,8 @@ export default class Medications extends PureComponent {
         isDetailPanelVisible: true,
         isBtnExpandVisible: true,
         isBtnCreateVisible: isButtonVisible(hiddenButtons, 'create', true),
-        isCreatePanelVisible: false
+        isCreatePanelVisible: false,
+        offset,
       })
     }
     if (this.context.router.history.location.pathname === `${clientUrls.PATIENTS}/${userId}/${clientUrls.MEDICATIONS}/create`) {
@@ -307,7 +312,7 @@ export default class Medications extends PureComponent {
   };
 
   render() {
-    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isSubmit, isOpenHourlySchedule, isLoading } = this.state;
+    const { selectedColumns, columnNameSortBy, sortingOrder, isSecondPanel, isDetailPanelVisible, isBtnExpandVisible, expandedPanel, openedPanel, isBtnCreateVisible, isCreatePanelVisible, editedPanel, offset, isSubmit, isOpenHourlySchedule, isLoading, listPerPageAmount } = this.state;
     const { allMedications, medicationsDetailFormState, medicationsCreateFormState, prescriptionPanelFormState, medicationDetail } = this.props;
 
     const isPanelDetails = (expandedPanel === MEDICATIONS_DETAIL || expandedPanel === MEDICATION_PANEL || expandedPanel === PRESCRIPTION_PANEL || expandedPanel === WARNINGS_PANEL || expandedPanel === CHANGE_HISTORY_PANEL || expandedPanel === SYSTEM_INFO_PANEL);
@@ -385,6 +390,7 @@ export default class Medications extends PureComponent {
                 onCreate={this.handleCreate}
                 id={sourceId}
                 isLoading={isLoading}
+                listPerPageAmount={listPerPageAmount}
               />
             </div>
           </Col> : null}

--- a/src/components/pages/Medications/__tests__/__snapshots__/Medications.test.js.snap
+++ b/src/components/pages/Medications/__tests__/__snapshots__/Medications.test.js.snap
@@ -239,7 +239,7 @@ exports[`Component <Medications /> should renders correctly and testing context 
             isBtnCreateVisible={true}
             isLoading={true}
             listPerPageAmount={10}
-            offset={0}
+            offset={-10}
             onCellClick={[Function]}
             onCreate={[Function]}
             onHeaderCellClick={[Function]}


### PR DESCRIPTION
Added some functionality to Core pages to fix the problem with selecting empty item from Patient Summary screen. 
Now when user click on Medication item on Patient Summary screen he'll see the page with current item.

This PR relate to task #56 (https://waffle.io/RippleOSI/combined-development-view/cards/5bcdf84cc5d15a00b271be98)