### PR TITLE
Space in User ID

### DIFF
--- a/src/components/containers/Header/HeaderToolbar/HeaderToolbar.js
+++ b/src/components/containers/Header/HeaderToolbar/HeaderToolbar.js
@@ -99,7 +99,7 @@ class HeaderToolbar extends PureComponent {
                     </div>
                     <div className="column-2">
                       <div className="patient-info-item"><span className="key">Gender:</span> {gender}</div>
-                      <div className="patient-info-item"><span className="key">NHS No.</span><span>{formatNHSNumber(userId)}</span></div>
+                      <div className="patient-info-item"><span className="key">NHS No.</span><span> {formatNHSNumber(userId)}</span></div>
                     </div>
                   </div>
                   <div className="patient-info-group-1">

--- a/src/components/containers/Header/__tests__/HeaderToolbar.test.js
+++ b/src/components/containers/Header/__tests__/HeaderToolbar.test.js
@@ -50,7 +50,7 @@ describe('Component <HeaderToolbar />', () => {
     expect(headerToolbar.find('.patient-info-item').at(0).html()).toEqual('<div class="patient-info-item"><span class="key">D.O.B.</span> 06-Jun-1944</div>');
     expect(headerToolbar.find('.patient-info-item').at(1).html()).toEqual('<div class="patient-info-item"><span class="key">Phone:</span> (011981) 32362</div>');
     expect(headerToolbar.find('.patient-info-item').at(2).html()).toEqual('<div class="patient-info-item"><span class="key">Gender:</span> Male</div>');
-    expect(headerToolbar.find('.patient-info-item').at(3).html()).toEqual('<div class="patient-info-item"><span class="key">NHS No.</span><span>999 999 9000</span></div>');
+    expect(headerToolbar.find('.patient-info-item').at(3).html()).toEqual('<div class="patient-info-item"><span class="key">NHS No.</span><span> 999 999 9000</span></div>');
     expect(headerToolbar.find('.patient-info-item').at(4).html()).toEqual('<div class="patient-info-item significant hidden-xs">Ivor Cox</div>');
     expect(headerToolbar.find('.patient-info-item').at(5).html()).toEqual('<div class="patient-info-item"><span class="key">Doctor:</span> Goff Carolyn D.</div>');
     expect(headerToolbar.find('.patient-info-item').at(6).html()).toEqual('<div class="patient-info-item"><span class="key">Address:</span> Hamilton Practice, 5544 Ante Street, Hamilton, Lanarkshire, N06 5LP</div>');

--- a/src/components/containers/Header/__tests__/__snapshots__/HeaderToolbar.test.js.snap
+++ b/src/components/containers/Header/__tests__/__snapshots__/HeaderToolbar.test.js.snap
@@ -98,6 +98,7 @@ exports[`Component <HeaderToolbar /> should renders correctly 1`] = `
                     NHS No.
                   </span>
                   <span>
+                     
                     999 999 9000
                   </span>
                 </div>


### PR DESCRIPTION
E2E-tests checked user ID in HeaderToolbar component and find:
"NHS No.999 999 9000"
instead of:
"NHS No. 999 999 9000"