### PR TITLE
hide birthdate

### DIFF
--- a/src/components/containers/UserPanel/UserAccountPanel.js
+++ b/src/components/containers/UserPanel/UserAccountPanel.js
@@ -65,7 +65,7 @@ export default class UserAccountPanel extends PureComponent {
           <div className="user-profile-info__descr">
             <div className="user-profile-info__item role">User Role:{user.role}</div>
             <div className="user-profile-info__item email">{user.email}</div>
-            {get(user, 'dateOfBirth', null)
+              {(get(themeConfigs, 'isShowUserBirthday', false) && get(user, 'dateOfBirth', null))
               ? <div className="user-profile-info__item birthday">Date of Birth: {getDDMMMYYYY(user.dateOfBirth)}</div>
               : null
             }

--- a/src/themes.config.js
+++ b/src/themes.config.js
@@ -20,6 +20,7 @@ const mainThemeConfigs = {
   patientsSummaryHasPreviewSettings: false,
   dashboardBeing: {},
   isShowUserPhoto: true,
+  isShowUserBirthday: true,
   isShowUserProfileSettings: true,
   isShowUserProfileSpecification: true,
   isShowPagesBannersImages: false,


### PR DESCRIPTION
For the issue: https://github.com/LeedsCC/Helm-PHR-Project/issues/42

What was done:
1) Added new parameter 'isShowUserBirthday' to theme settings. Parameter is **true** in Core and **false** by default.
2) User birthday will be shown depends on this parameter is true/false.