### PR TITLE
Table interactivity

### DIFF
--- a/src/components/containers/SortableTable/SortableTableRow.js
+++ b/src/components/containers/SortableTable/SortableTableRow.js
@@ -23,7 +23,7 @@ export default class SortableTableRow extends PureComponent {
     const rowDataItem = rowData.map((rowItem, index) => {
       if (rowItem.highlighter) {
         return (
-          <td data-table-hover data-th={headers[index].title} key={_.uniqueId('__SortableTableRow__')} name={rowItem.name} onClick={() => onCellClick(sourceId)} className={classNames('highlighter-wrapper', { 'sorted': rowItem.name === columnNameSortBy })}>
+          <td data-table-hover data-th={headers[index].title} key={_.uniqueId('__SortableTableRow__')} name={rowItem.name} onClick={() => onCellClick(sourceId)} className={classNames('highlighter-wrapper', { 'sorted': rowItem.name === columnNameSortBy })} tabIndex={( index == 0 ? 0 : -1 )}>
             <span>
               <span className={`highlighter-${rowItem.highlighter}`} />
               <span>{ rowItem.value }</span>
@@ -31,7 +31,13 @@ export default class SortableTableRow extends PureComponent {
           </td>
         )
       }
-      return <td data-table-hover data-th={headers[index].title} key={_.uniqueId('__SortableTableRow__')} name={rowItem.name} onClick={() => onCellClick(sourceId)} className={classNames({ 'sorted': rowItem.name === columnNameSortBy })}>{rowItem.value}</td>
+      return <td data-table-hover data-th={headers[index].title} key={_.uniqueId('__SortableTableRow__')} name={rowItem.name}
+        onClick={() => onCellClick(sourceId)}
+        onKeyPress={(event) => {if( event.key == 'Enter' ){ onCellClick(sourceId) }} }
+        className={classNames({ 'sorted': rowItem.name === columnNameSortBy })}
+        tabIndex={( index == 0 ? 0 : -1 )}>
+        {rowItem.value}
+      </td>
     });
 
     return (<tr className={classNames({ 'info': id === sourceId })}>

--- a/src/components/containers/SortableTable/__tests__/__snapshots__/SortableTable.test.js.snap
+++ b/src/components/containers/SortableTable/__tests__/__snapshots__/SortableTable.test.js.snap
@@ -241,6 +241,8 @@ exports[`Component <SortableTable /> should renders with props correctly 1`] = `
             key="__SortableTableRow__9"
             name="cause"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex={0}
           >
             3123123123
           </td>
@@ -251,6 +253,8 @@ exports[`Component <SortableTable /> should renders with props correctly 1`] = `
             key="__SortableTableRow__10"
             name="reaction"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex={-1}
           >
             123123
           </td>
@@ -261,6 +265,8 @@ exports[`Component <SortableTable /> should renders with props correctly 1`] = `
             key="__SortableTableRow__11"
             name="sourceId"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex={-1}
           >
             c2c286c1-2d65-4e8a-857b-1dcf3f0fa4d4
           </td>
@@ -334,6 +340,8 @@ exports[`Component <SortableTable /> should renders with props correctly 1`] = `
             key="__SortableTableRow__12"
             name="cause"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex={0}
           >
             123
           </td>
@@ -344,6 +352,8 @@ exports[`Component <SortableTable /> should renders with props correctly 1`] = `
             key="__SortableTableRow__13"
             name="reaction"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex={-1}
           >
             123
           </td>
@@ -354,6 +364,8 @@ exports[`Component <SortableTable /> should renders with props correctly 1`] = `
             key="__SortableTableRow__14"
             name="sourceId"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex={-1}
           >
             test
           </td>

--- a/src/components/containers/SortableTable/__tests__/__snapshots__/SortableTableRow.test.js.snap
+++ b/src/components/containers/SortableTable/__tests__/__snapshots__/SortableTableRow.test.js.snap
@@ -114,6 +114,8 @@ exports[`Component <SortableTableRow /> should renders mount with prop rowDataWa
       key="__SortableTableRow__1"
       name="name"
       onClick={[Function]}
+      onKeyPress={[Function]}
+      tabIndex={0}
     >
       Ezra Gordon
     </td>
@@ -124,6 +126,7 @@ exports[`Component <SortableTableRow /> should renders mount with prop rowDataWa
       key="__SortableTableRow__2"
       name="address"
       onClick={[Function]}
+      tabIndex={-1}
     >
       <span>
         <span
@@ -141,6 +144,8 @@ exports[`Component <SortableTableRow /> should renders mount with prop rowDataWa
       key="__SortableTableRow__3"
       name="dateOfBirth"
       onClick={[Function]}
+      onKeyPress={[Function]}
+      tabIndex={-1}
     >
       19-Feb-1938
     </td>
@@ -151,6 +156,8 @@ exports[`Component <SortableTableRow /> should renders mount with prop rowDataWa
       key="__SortableTableRow__4"
       name="id"
       onClick={[Function]}
+      onKeyPress={[Function]}
+      tabIndex={-1}
     >
       9999999024
     </td>
@@ -161,6 +168,8 @@ exports[`Component <SortableTableRow /> should renders mount with prop rowDataWa
       key="__SortableTableRow__5"
       name="viewPatientNavigation"
       onClick={[Function]}
+      onKeyPress={[Function]}
+      tabIndex={-1}
     >
       test
     </td>
@@ -179,6 +188,8 @@ exports[`Component <SortableTableRow /> should renders shallow with prop rowData
     key="__SortableTableRow__6"
     name="name"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
   >
     test
   </td>
@@ -189,6 +200,7 @@ exports[`Component <SortableTableRow /> should renders shallow with prop rowData
     key="__SortableTableRow__7"
     name="address"
     onClick={[Function]}
+    tabIndex={-1}
   >
     <span>
       <span
@@ -206,6 +218,8 @@ exports[`Component <SortableTableRow /> should renders shallow with prop rowData
     key="__SortableTableRow__8"
     name="dateOfBirth"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={-1}
   >
     19-Feb-1938
   </td>
@@ -216,6 +230,8 @@ exports[`Component <SortableTableRow /> should renders shallow with prop rowData
     key="__SortableTableRow__9"
     name="id"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={-1}
   >
     9999999024
   </td>
@@ -226,6 +242,8 @@ exports[`Component <SortableTableRow /> should renders shallow with prop rowData
     key="__SortableTableRow__10"
     name="viewPatientNavigation"
     onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={-1}
   >
     test
   </td>

--- a/src/components/pages/PatientsSummary/SimpleDashboardPanel.js
+++ b/src/components/pages/PatientsSummary/SimpleDashboardPanel.js
@@ -30,7 +30,13 @@ const SimpleDashboardPanel = ({ id, title, items, goToState, state, isHasPreview
           ? <ul className="board-list">
             {filterItemsArray.map(item =>
               <li className="board-list-item" key={_.uniqueId('__SimpleDashboardPanel__item__')}>
-                {item.text ? <span className="board-list-link" onClick={() => goToState(`${state}/${item.sourceId}`, item.link)} title={item.text}>{item.text}</span> : null}
+                {item.text ? <a className="board-list-link"
+                  onClick={() => goToState(`${state}/${item.sourceId}`, item.link)}
+                  onKeyPress={(event) => {if( event.key == 'Enter' ){ goToState(`${state}/${item.sourceId}`, item.link) }} }
+                  title={item.text}
+                  tabIndex="0">
+                    {item.text}
+                  </a> : null}
               </li>)}
           </ul>
           : null}

--- a/src/components/pages/PatientsSummary/__tests__/__snapshots__/SimpleDashboardPanel.test.js.snap
+++ b/src/components/pages/PatientsSummary/__tests__/__snapshots__/SimpleDashboardPanel.test.js.snap
@@ -40,25 +40,29 @@ exports[`Component <SimpleDashboardPanel /> should renders with all props correc
           className="board-list-item"
           key="__SimpleDashboardPanel__item__1"
         >
-          <span
+          <a
             className="board-list-link"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex="0"
             title="John Smithy"
           >
             John Smithy
-          </span>
+          </a>
         </li>
         <li
           className="board-list-item"
           key="__SimpleDashboardPanel__item__2"
         >
-          <span
+          <a
             className="board-list-link"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            tabIndex="0"
             title="Andrew Finch"
           >
             Andrew Finch
-          </span>
+          </a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Fixes LeedsCC/Helm-PHR-Project/issues/77

Allows users to tab through rows within the patient summary widgets and tables. Pressing 'Enter' on any selected row performs the same operation as clicking on the element.

@BogdanScherban Could you take a quick look at this and check the way I've bound onKeyPress events to the TD elements? Please advise if there's a better way to handle this?